### PR TITLE
delete useless port forwarding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,6 @@ services:
   runner:
     <<: *backend
     command: /bin/bash
-    ports:
-      - '3000:3000'
-      - '3002:3002'
 
   rails:
     <<: *backend


### PR DESCRIPTION
The `runner` and `rails` containers were forwarding the 3000 port and that was crashing.
The `runner` container doesn't really need a port forward at the moment.