### PR TITLE
Add bundle install and yarn install to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,19 @@ ENV PATH /app/bin:$PATH
 RUN gem update --system && \
     gem install bundler:$BUNDLER_VERSION
 
+# Install bundle of gems
+WORKDIR /tmp
+ADD Gemfile /tmp/
+ADD Gemfile.lock /tmp/
+RUN bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
+
+
 # Create a directory for the app code
 RUN mkdir -p /app
 
 WORKDIR /app
+
+# Install Yarn packages
+ADD package.json /app/
+ADD yarn.lock /app/
+RUN yarn install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ x-app: &app
     context: .
     dockerfile: ./Dockerfile
     args:
-      RUBY_VERSION: '2.6.3'
+      RUBY_VERSION: '2.6.5'
       PG_MAJOR: '11'
       NODE_MAJOR: '10'
       YARN_VERSION: '1.13.0'
-      BUNDLER_VERSION: '2.0.2'
+      BUNDLER_VERSION: '2.1.3'
   environment: &env
     NODE_ENV: development
     RAILS_ENV: ${RAILS_ENV:-development}
@@ -90,7 +90,7 @@ services:
     <<: *app
     command: ./bin/webpack-dev-server
     ports:
-      - '3035:3035'
+      - '3036:3036'
     volumes:
       - .:/app:cached
       - bundle:/usr/local/bundle


### PR DESCRIPTION
- Fixes some versions and ports at docker-compose.yml
- Adds `bundle install` and `yarn install` to Dockerfile

Now, the whole process should be:


```
# terminal 1

$ cd chaskiq
$ docker-compose build
$ docker-compose up
```

```
# terminal 2

$ cd chaskiq
$ docker-compose run runner
$ rake db:migrate
(exit)
```