### PR TITLE
Fixing one-click heroku deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -88,7 +88,7 @@
       "plan": "heroku-redis"
     },
     {
-      "plan": "bugsnag:Tauron"
+      "plan": "bugsnag:tauron2"
     },
     {
       "plan": "heroku-postgresql",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43896/75462836-b56c4100-5939-11ea-9b3f-31d8f1e7d23d.png)

When deploying with heroku, bugsnag could not be found.

Bugsnag addon for heroku that works is tauron2