### PR TITLE
Short SHA as docker image tag

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,11 +16,6 @@ jobs:
 
     steps:
 
-    - name: Get Short SHA
-      id: vars
-      run: |
-        echo ::set-output name=short_sha::$(git rev-parse --short=7 ${{ github.sha }})
-
     - name: Login into Registry
       uses: azure/docker-login@v1
       with:
@@ -28,6 +23,11 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
+
+    - name: Get Short SHA
+      id: vars
+      run: |
+        echo ::set-output name=short_sha::$(git rev-parse --short=7 ${{ github.sha }})
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Push Docker Image
 
 on:
   push:
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+    - name: Get Short SHA
+      id: vars
+      run: |
+        echo ::set-output name=short_sha::$(git rev-parse --short=7 ${{ github.sha }})
+
     - name: Login into Registry
       uses: azure/docker-login@v1
       with:
@@ -22,7 +28,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
-    
+
     - name: Build the Docker image
       run: |
         docker build --build-arg APP_ENV=production \
@@ -36,6 +42,7 @@ jobs:
 
     - name: Tag and Push Docker image
       run: |
-        docker tag $GITHUB_REPOSITORY $GITHUB_REPOSITORY:$GITHUB_SHA
-        docker push $GITHUB_REPOSITORY:$GITHUB_SHA
-
+        docker tag $GITHUB_REPOSITORY $GITHUB_REPOSITORY:$SHORT_SHA
+        docker push $GITHUB_REPOSITORY:$SHORT_SHA
+      env:
+        SHORT_SHA: ${{ steps.vars.outputs.short_sha }}


### PR DESCRIPTION
It replaces long SHA to tag docker images on DockerHub on push.