### PR TITLE
Enable PullPreview action (pullpreview.com)

### DIFF
--- a/.env.pullpreview
+++ b/.env.pullpreview
@@ -1,0 +1,16 @@
+SNS_CONFIGURATION_SET=metrics
+
+SES_ADDRESS=email-smtp.us-east-1.amazonaws.com
+SES_USER_NAME=
+SES_PASSWORD=
+
+AWS_ACCESS_KEY_ID=abcd
+AWS_SECRET_ACCESS_KEY=efgh
+
+AWS_S3_BUCKET=bucket
+AWS_S3_REGION=us-east-1
+
+FULLCONTACT_TOKEN=
+
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=password

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -1,0 +1,24 @@
+name: PullPreview
+on:
+  push:
+  pull_request:
+    types: [labeled, unlabeled, closed]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - uses: pullpreview/action@v3
+      with:
+        admins: crohr,michelson
+        always_on: master
+        default_port: 443
+        instance_type: medium_2_0
+        compose_files: docker-compose.pullpreview.yml
+      env:
+        AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+        AWS_REGION: "us-east-1"

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: pullpreview/action@v3
       with:
-        admins: crohr,michelson
+        admins: michelson
         always_on: master
         default_port: 443
         instance_type: medium_2_0

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ stats.json
 .DS_Store
 app/javascript/old-src
 .envrc
-
+*.swp

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,10 +17,6 @@ if App.none?
      domain_url: domain
   )
 
-  Doorkeeper::Application.create(
-     name: "authapp", 
-     #redirect_uri: "#{domain}/callback"
-  )
 
   AppPackagesCatalog.import unless Rails.env.test?
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,14 +11,16 @@ require 'app_packages_catalog'
 
 domain = ENV['HOST'] || 'http://localhost:3000'
 
-app = App.create(
-   name: 'test app', 
-   domain_url: domain
-)
+if App.none?
+  app = App.create(
+     name: 'test app', 
+     domain_url: domain
+  )
 
-Doorkeeper::Application.create(
-   name: "authapp", 
-   #redirect_uri: "#{domain}/callback"
-)
+  Doorkeeper::Application.create(
+     name: "authapp", 
+     #redirect_uri: "#{domain}/callback"
+  )
 
-AppPackagesCatalog.import unless Rails.env.test?
+  AppPackagesCatalog.import unless Rails.env.test?
+end

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -19,6 +19,7 @@ x-app: &app
     ASSET_HOST: "${PULLPREVIEW_URL:-http://localhost:3000}"
     RAILS_SERVE_STATIC_FILES: "true"
     RAILS_LOG_TO_STDOUT: "true"
+    SKIP_SUBDOMAIN_CHECK: "true"
 
 x-backend: &backend
   <<: *app
@@ -79,6 +80,8 @@ services:
     image: caddy:2-alpine
     command: "caddy reverse-proxy --from '${PULLPREVIEW_URL}' --to rails:3000"
     restart: unless-stopped
+    volumes:
+      - proxy:/data/caddy
     depends_on:
       - rails
     ports:
@@ -87,3 +90,4 @@ services:
 volumes:
   postgres:
   redis:
+  proxy:

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -1,0 +1,89 @@
+version: '2.4'
+
+x-app: &app
+  build:
+    context: .
+    dockerfile: ./Dockerfile
+    args:
+      APP_ENV: production
+      RUBY_VERSION: '2.6.5'
+      PG_MAJOR: '11'
+      NODE_MAJOR: '10'
+      YARN_VERSION: '1.13.0'
+      BUNDLER_VERSION: '2.0.2'
+  environment: &env
+    NODE_ENV: production
+    RAILS_ENV: ${RAILS_ENV:-production}
+    SECRET_KEY_BASE: mysecretchangeme
+    HOST: "${PULLPREVIEW_URL:-http://localhost:3000}"
+    ASSET_HOST: "${PULLPREVIEW_URL:-http://localhost:3000}"
+    RAILS_SERVE_STATIC_FILES: "true"
+    RAILS_LOG_TO_STDOUT: "true"
+
+x-backend: &backend
+  <<: *app
+  env_file: .env.pullpreview
+  environment:
+    <<: *env
+    REDIS_URL: redis://redis:6379/
+    DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
+    WEB_CONCURRENCY: 2
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+
+services:
+  seeder:
+    <<: *backend
+    command: bundle exec rake db:migrate db:seed admin_generator
+    restart: on-failure
+
+  rails:
+    <<: *backend
+    command: bundle exec rails server -b 0.0.0.0
+    ports:
+      - '3000'
+
+  sidekiq:
+    <<: *backend
+    command: bundle exec sidekiq -C config/sidekiq.yml
+
+  postgres:
+    image: postgres:11.1
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - 5432
+    healthcheck:
+      test: pg_isready -U postgres -h 127.0.0.1
+      interval: 5s
+
+  redis:
+    image: redis:3.2-alpine
+    volumes:
+      - redis:/data
+    ports:
+      - 6379
+    healthcheck:
+      test: redis-cli ping
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
+  proxy:
+    image: caddy:2-alpine
+    command: "caddy reverse-proxy --from '${PULLPREVIEW_URL}' --to rails:3000"
+    restart: unless-stopped
+    depends_on:
+      - rails
+    ports:
+      - "443:443"
+
+volumes:
+  postgres:
+  redis:

--- a/lib/subdomain_routes.rb
+++ b/lib/subdomain_routes.rb
@@ -17,6 +17,7 @@ end
 
 class SubdomainOrDomain
   def self.matches?(request)
+    return false if ENV.fetch("SKIP_SUBDOMAIN_CHECK", "false") == "true"
     if request.subdomain.present? && !APP_SUBDOMAINS.include?(request.subdomain)
       true
     # elsif request.host != 'www.#{DOMAIN}'

--- a/lib/tasks/admin_generator.rake
+++ b/lib/tasks/admin_generator.rake
@@ -1,8 +1,10 @@
 # desc "Explaining what the task does"
 task admin_generator: :environment do
   app = App.first
-  app.add_admin(Agent.create(
-                  email: ENV['ADMIN_EMAIL'],
-                  password: ENV['ADMIN_PASSWORD']
-                ))
+  if app.app_users.find_by(email: ENV['ADMIN_EMAIL']).nil?
+    app.add_admin(Agent.create(
+                    email: ENV['ADMIN_EMAIL'],
+                    password: ENV['ADMIN_PASSWORD']
+                  ))
+  end
 end


### PR DESCRIPTION
This adds a docker-compose for use with the [PullPreview action](https://pullpreview.com), complete with HTTPS support from Let's Encrypt.

To avoid repetition you could switch to a base docker-compose.yml file, and then have a docker-compose.development.yml and docker-compose.pullpreview.yml, each with just the extensions required. See https://docs.docker.com/compose/extends/ for details.

For this to work in your repository, you will have to add 2 secrets into the "Secrets" section of the GitHub repo:

* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY`

I would recommend that you create at least a separate IAM user for this (see https://github.com/pullpreview/action/wiki/Recommended-AWS-Configuration).

And to test on a PR you'll also need to create the `pullpreview` label, and apply it to the PR. Currently it will always auto-deploy the `master` branch. If you don't want this, remove the `always_on` option in the workflow file.

Let me know if I can help with anything else! The working PR against my repo is at https://github.com/pullpreview/chaskiq/pull/1.