### PR TITLE
Responsive Articles in Help Center

### DIFF
--- a/app/javascript/src/pages/docs/article.js
+++ b/app/javascript/src/pages/docs/article.js
@@ -60,7 +60,7 @@ export default function Article (props) {
 
   return (
     <div className="flex flex-row items-center justify-center bg-gray-100">
-      <div className="rounded shadow lg:p-12 m-2 lg:m-8 px-2 lg:w-10/12 bg-white">
+      <div className="w-full rounded shadow lg:p-12 m-2 lg:m-8 px-2 lg:w-10/12 bg-white p-2">
         {article ? (
           <div className={'text-xs lg:text-sm'}>
             <Breadcrumbs


### PR DESCRIPTION
Hi @michelson,

When reading the article [installation guides on mac](https://dev.chaskiq.io/en/articles/installation-on-mac) in chaskiq website on safari for iphone I could not read the entire article.

So I made the changes in the section you told me to fix this and make it more responsive
