### PR TITLE
Fix help center lang dropdown

### DIFF
--- a/app/javascript/packages/docs/src/site/Dropdown.tsx
+++ b/app/javascript/packages/docs/src/site/Dropdown.tsx
@@ -12,7 +12,7 @@ export default function Example({
     <Menu as="div" className="relative inline-block text-left">
       <div>
         <Menu.Button className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-white bg-black rounded-md bg-opacity-20 hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75">
-          <span style={{ marginRight: '4px' }}>{label}</span> {icon}
+          <span className={'mr-1'}>{label}</span> {icon}
         </Menu.Button>
       </div>
       <Transition
@@ -25,8 +25,7 @@ export default function Example({
         leaveTo="transform opacity-0 scale-95"
       >
         <Menu.Items className="absolute right-0 w-56 mt-2 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-50">
-          <div
-            className="px-1 py-1">
+          <div className="px-1 py-1">
             {options.map((item) => (
               <Menu.Item>
                 {({ active }) => (
@@ -36,7 +35,7 @@ export default function Example({
                       active ? 'bg-violet-500 text-gray-600' : 'text-gray-900'
                     } group flex items-center w-full px-2 py-2 text-sm hover:bg-gray-200`}
                   >
-                    <h3>{item.name}</h3>
+                    <span>{item.name}</span>
                   </button>
                 )}
               </Menu.Item>

--- a/app/javascript/packages/docs/src/site/Dropdown.tsx
+++ b/app/javascript/packages/docs/src/site/Dropdown.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { Fragment, useEffect, useRef, useState } from 'react';
 
-export default function Example({ options, icon, filterHandler }) {
+export default function Example({ options, label="Options", icon, filterHandler }) {
   return (
     <Menu as="div" className="relative inline-block text-left">
       <div>
         <Menu.Button className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-white bg-black rounded-md bg-opacity-20 hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75">
-          Options {icon}
+          <span style={{ marginRight: '4px' }}>{label}</span> {icon}
         </Menu.Button>
       </div>
       <Transition
@@ -19,8 +19,8 @@ export default function Example({ options, icon, filterHandler }) {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 w-56 mt-2 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-          <div className="px-1 py-1 ">
+        <Menu.Items className="absolute right-0 w-56 mt-2 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-50">
+          <div className="px-1 py-1" style= {{ display: 'flex', flexDirection: 'column', rowGap: '4px' }}>
             {options.map((item) => (
               <Menu.Item>
                 {({ active }) => (
@@ -28,9 +28,8 @@ export default function Example({ options, icon, filterHandler }) {
                     onClick={() => filterHandler(item)}
                     className={`${
                       active ? 'bg-violet-500 text-gray-600' : 'text-gray-900'
-                    } group flex rounded-md items-center w-full px-2 py-2 text-sm`}
-                  >
-                    {item.name}
+                    } group flex items-center w-full px-2 text-sm hover:bg-gray-200`}>
+                    <h3>{item.name}</h3>
                   </button>
                 )}
               </Menu.Item>

--- a/app/javascript/packages/docs/src/site/Dropdown.tsx
+++ b/app/javascript/packages/docs/src/site/Dropdown.tsx
@@ -26,9 +26,7 @@ export default function Example({
       >
         <Menu.Items className="absolute right-0 w-56 mt-2 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-50">
           <div
-            className="px-1 py-1"
-            style={{ display: 'flex', flexDirection: 'column', rowGap: '4px' }}
-          >
+            className="px-1 py-1">
             {options.map((item) => (
               <Menu.Item>
                 {({ active }) => (

--- a/app/javascript/packages/docs/src/site/Dropdown.tsx
+++ b/app/javascript/packages/docs/src/site/Dropdown.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { Fragment, useEffect, useRef, useState } from 'react';
 
-export default function Example({ options, label="Options", icon, filterHandler }) {
+export default function Example({
+  options,
+  label = 'Options',
+  icon,
+  filterHandler,
+}) {
   return (
     <Menu as="div" className="relative inline-block text-left">
       <div>
@@ -20,7 +25,10 @@ export default function Example({ options, label="Options", icon, filterHandler 
         leaveTo="transform opacity-0 scale-95"
       >
         <Menu.Items className="absolute right-0 w-56 mt-2 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-50">
-          <div className="px-1 py-1" style= {{ display: 'flex', flexDirection: 'column', rowGap: '4px' }}>
+          <div
+            className="px-1 py-1"
+            style={{ display: 'flex', flexDirection: 'column', rowGap: '4px' }}
+          >
             {options.map((item) => (
               <Menu.Item>
                 {({ active }) => (
@@ -28,7 +36,8 @@ export default function Example({ options, label="Options", icon, filterHandler 
                     onClick={() => filterHandler(item)}
                     className={`${
                       active ? 'bg-violet-500 text-gray-600' : 'text-gray-900'
-                    } group flex items-center w-full px-2 text-sm hover:bg-gray-200`}>
+                    } group flex items-center w-full px-2 py-2 text-sm hover:bg-gray-200`}
+                  >
                     <h3>{item.name}</h3>
                   </button>
                 )}

--- a/app/javascript/packages/docs/src/site/docs.tsx
+++ b/app/javascript/packages/docs/src/site/docs.tsx
@@ -100,7 +100,7 @@ function Docs(props) {
                       onClick={(_e) => (window.location = settings.website)}
                     >
                       <LaunchIcon />
-                      <span style={{ marginLeft: '4px' }}>
+                      <span className={'ml-1'}>
                         {' Go to'} {settings.siteTitle}
                       </span>
                     </button>

--- a/app/javascript/packages/docs/src/site/docs.tsx
+++ b/app/javascript/packages/docs/src/site/docs.tsx
@@ -100,7 +100,9 @@ function Docs(props) {
                       onClick={(_e) => (window.location = settings.website)}
                     >
                       <LaunchIcon />
-                      <span style={{ marginLeft: '4px' }}>{' Go to'} {settings.siteTitle}</span>
+                      <span style={{ marginLeft: '4px' }}>
+                        {' Go to'} {settings.siteTitle}
+                      </span>
                     </button>
 
                     <div>

--- a/app/javascript/packages/docs/src/site/docs.tsx
+++ b/app/javascript/packages/docs/src/site/docs.tsx
@@ -100,7 +100,7 @@ function Docs(props) {
                       onClick={(_e) => (window.location = settings.website)}
                     >
                       <LaunchIcon />
-                      {' Go to'} {settings.siteTitle}
+                      <span style={{ marginLeft: '4px' }}>{' Go to'} {settings.siteTitle}</span>
                     </button>
 
                     <div>


### PR DESCRIPTION
The helpcenter's language dropdown opened below the search field.

Added hover feedback on language options as well as small margins between icons and labels.


Before :

![image](https://user-images.githubusercontent.com/88848584/137397144-7c20a596-4664-4ff8-a30d-36928a27ba15.png)

After :

![image](https://user-images.githubusercontent.com/88848584/137397241-a66ff65d-20e8-47be-b9e5-dcf5af409b37.png)

