### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/app/javascript/packages/components/src/utils/htmlSanitize.ts
+++ b/app/javascript/packages/components/src/utils/htmlSanitize.ts
@@ -6,6 +6,6 @@ export default function extractContent(html) {
 export function escapeHTML(unsafe) {
   return unsafe.replace(
     /[\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u00FF]/g,
-    (c) => '&#' + ('000' + c.charCodeAt(0)).substr(-4, 4) + ';'
+    (c) => '&#' + ('000' + c.charCodeAt(0)).slice(-4) + ';'
   );
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.