### PR TITLE
User with agent role not able to change own profile info

### DIFF
--- a/app/graphql/mutations/agents/update_agent.rb
+++ b/app/graphql/mutations/agents/update_agent.rb
@@ -13,16 +13,15 @@ module Mutations
         agent = app.agents.find_by(email: email) # , name: 'John Doe')
 
         authorize! agent,
-                   to: :can_manage_own_profile?,
+                   to: :can_manage_profile?,
                    with: AppPolicy,
                    context: {
                      app: app
                    }
 
         data = params.permit(
-          :name,
           :avatar,
-          :lang,
+          :name,
           :first_name,
           :last_name,
           :country,
@@ -30,7 +29,13 @@ module Mutations
           :region,
           :region_code,
           :enable_deliveries,
-          :available
+          :lang,
+          :permissions,
+          :area_of_expertise,
+          :specialization,
+          :phone_number,
+          :address,
+          :availability,
         )
 
         # data.merge!({avatar: avatar}) if avatar.present?

--- a/app/graphql/mutations/agents/update_agent_role.rb
+++ b/app/graphql/mutations/agents/update_agent_role.rb
@@ -19,16 +19,8 @@ module Mutations
 
         agent = role&.agent # , name: 'John Doe')
 
-        authorize! role,
-                   to: :can_manage_own_profile?,
-                   with: AppPolicy,
-                   context: {
-                     app: app
-                   }
-
         data = params.permit(
           :avatar,
-          :lang,
           :name,
           :first_name,
           :last_name,
@@ -37,15 +29,13 @@ module Mutations
           :region,
           :region_code,
           :enable_deliveries,
-          :available,
-          # :access_list,
-          :address,
+          :lang,
+          :permissions,
           :area_of_expertise,
-          :availability,
-          :phone_number,
           :specialization,
-          :enable_deliveries,
-          :available
+          :phone_number,
+          :address,
+          :availability,
         )
 
         # role.update(data)

--- a/app/javascript/src/pages/AgentProfile.tsx
+++ b/app/javascript/src/pages/AgentProfile.tsx
@@ -27,7 +27,6 @@ import {
   START_CONVERSATION,
   APP_USER_UPDATE_STATE,
   UPDATE_AGENT,
-  UPDATE_AGENT_ROLE,
 } from '@chaskiq/store/src/graphql/mutations';
 
 import {
@@ -133,10 +132,10 @@ class ProfilePage extends Component<ProfilePageProps, ProfilePageState> {
 
   handleData = (option) => {
     graphql(
-      UPDATE_AGENT_ROLE,
+      UPDATE_AGENT,
       {
         appKey: this.props.app.key,
-        id: this.state.agent.id + '',
+        email: this.state.agent.email,
         params: option.app,
       },
       {

--- a/app/policies/app_policy.rb
+++ b/app/policies/app_policy.rb
@@ -47,8 +47,8 @@ class AppPolicy < ActionPolicy::Base
     end
   end
 
-  def can_manage_own_profile?
-    can_manage_team? || @record.agent == @user
+  def can_manage_profile?
+    can_manage_team? || @record == @user
   end
 
   def find_role_by_resource


### PR DESCRIPTION
**Purpose**
The user was unable to update their own profile because the AgentProfile was using the Mutations::Agents::UpdateAgentRole mutation instead of the Mutations::Agents::UpdateAgent mutation.  The Mutations::Agents::UpdateAgentRole mutation requires that the user have the 'manage team' permission while the Mutations::Agents::UpdateAgent mutation requires the 'manage team' permission or that the profile being updated belongs to the user.

**Changes**
- Updated the AgentProfile component to use the UPDATE_AGENT mutation instead of UPDATE_AGENT_ROLE
- Updated Mutations::Agents::UpdateAgentRole mutation to accept the attributes defined in Agent.rb by the store_accessor method.
- Updated Mutations::Agents::UpdateAgent mutation to accept the attributes defined in Agent.rb by the store_accessor method.
- Renamed can_manage_own_profile to can_manage_profile to more accurately reflect what its doing.
