### PR TITLE
Change the bot starting text color to be more accessible

### DIFF
--- a/app/javascript/packages/messenger/src/client_messenger/styles/styled.tsx
+++ b/app/javascript/packages/messenger/src/client_messenger/styles/styled.tsx
@@ -503,7 +503,7 @@ export const AppPackageBlockButtonItem = styled.div`
 `;
 
 export const AppPackageBlockTextItem = styled.div`
-  ${() => tw`text-right mx-4 my-1.5 text-sm text-gray-400 font-light`}
+  ${() => tw`text-right mx-4 my-1.5 text-sm text-gray-700 font-light`}
   a {
     ${() => tw`text-sm text-gray-600 font-normal hover:text-gray-900`}
   }


### PR DESCRIPTION
Before:
![Screen Shot 2022-04-05 at 3 09 33 PM](https://user-images.githubusercontent.com/94011446/161845482-bb4c2a29-1beb-47fd-9c0c-efe44852c0f8.png)
After:
![Screen Shot 2022-04-05 at 3 46 01 PM](https://user-images.githubusercontent.com/94011446/161845501-ae905aff-ced7-43ba-a907-00fcbe847361.png)

