### PR TITLE
Accessible color for qualifier when complete

### DIFF
--- a/app/javascript/packages/components/src/components/packageBlocks/TextInput.tsx
+++ b/app/javascript/packages/components/src/components/packageBlocks/TextInput.tsx
@@ -71,7 +71,7 @@ export const TextInput = styled.input<TextInputProps>`
   ${(props) =>
     props.disabled
       ? `background: #f6f4f4 !important;
-    color: #ddd !important;`
+    color: #525252 !important;`
       : ''}
 `;
 


### PR DESCRIPTION
Changing the text color of the qualifier to be more visible/accessible when complete

Before:
<img width="277" alt="Screen Shot 2022-04-07 at 3 54 43 PM" src="https://user-images.githubusercontent.com/94011446/162290016-96bc6aa0-feaf-4b13-8941-d0a5daa9da35.png">
After:
<img width="272" alt="Screen Shot 2022-04-07 at 4 13 27 PM" src="https://user-images.githubusercontent.com/94011446/162290048-4a2ca97b-194a-4137-aefa-fd718f97a93c.png">

