### PR TITLE
Fix search in conversations to start on the first page

### DIFF
--- a/app/javascript/src/pages/conversations/Search.tsx
+++ b/app/javascript/src/pages/conversations/Search.tsx
@@ -33,7 +33,7 @@ function ConversationSearch({ _app, dispatch, conversations, asButton }) {
         },
         () => {
           setOpen(false);
-          fetchConversations({});
+          fetchConversations({ page: 1 });
         }
       )
     );


### PR DESCRIPTION
- When hitting enter in the search it would return the next page results
- Now it always starts on the first page of the search results when you hit enter and it loads the next results in the scroll