### PR TITLE
Remove appUser and just use appUserFragment for appUserUpdateData

### DIFF
--- a/app/javascript/packages/store/src/graphql/mutations.ts
+++ b/app/javascript/packages/store/src/graphql/mutations.ts
@@ -41,9 +41,7 @@ export const CREATE_APP = `
 export const APP_USER_UPDATE_STATE = `
   mutation AppUserUpdateData($appKey: String!, $id: String!, $state: String!){
     appUserUpdateData(appKey: $appKey, id: $id, state: $state){
-      appUser {
-        ${appUserFragment}
-      }
+      ${appUserFragment}
     }
   }
 `;


### PR DESCRIPTION
- Removed appUserFragment from appUser because the fragment contains the appUser object
- Fixes the error with archiving or blocking a user