### PR TITLE
Set text overflow to ellipsis for FilterMenu items.

### DIFF
--- a/app/javascript/packages/components/src/components/FilterMenu.tsx
+++ b/app/javascript/packages/components/src/components/FilterMenu.tsx
@@ -64,13 +64,13 @@ export default function FilterMenu({
 
               {option.icon && <i>{option.icon}</i>}
 
-              <div className="flex flex-col justify-between ml-2">
-                <span className="font-bold self-start dark:text-gray-100">
+              <div className="flex flex-col justify-between ml-2 overflow-hidden">
+                <span className="font-bold self-start dark:text-gray-100 w-full overflow-hidden text-ellipsis" title={option.name || option.title}>
                   {option.name || option.title}
                 </span>
 
                 {option.description && (
-                  <span className="text-xs text-left dark:text-gray-300">
+                  <span className="text-xs text-left dark:text-gray-300 w-full overflow-hidden text-ellipsis" title={option.description}>
                     {option.description}
                   </span>
                 )}


### PR DESCRIPTION
Before:
<img width="441" alt="Screen Shot 2022-05-24 at 5 04 05 PM" src="https://user-images.githubusercontent.com/94011572/170132082-fcff3124-b852-4285-8cef-2b52e9d319c1.png">

After:
<img width="317" alt="Screen Shot 2022-05-24 at 5 00 35 PM" src="https://user-images.githubusercontent.com/94011572/170131916-9516bad6-3cbf-4e6e-b630-0506ce676ff9.png">

