### PR TITLE
allow searching conversations by full name or email

### DIFF
--- a/app/graphql/types/app_type.rb
+++ b/app/graphql/types/app_type.rb
@@ -243,7 +243,7 @@ module Types
       sort_conversations(sort)
       @collection = @collection.tagged_with(tag) if tag.present?
       if term
-        query_term = :main_participant_postal_or_main_participant_phone_or_main_participant_last_name_or_main_participant_first_name_or_main_participant_name_or_messages_messageable_of_ConversationPartContent_type_text_content_i_cont_any
+        query_term = :main_participant_full_name_or_main_participant_name_or_main_participant_email_or_main_participant_postal_or_main_participant_phone_or_messages_messageable_of_ConversationPartContent_type_text_content_i_cont_any
         @collection = @collection.ransack(
           query_term => term
         ).result

--- a/app/models/app_user.rb
+++ b/app/models/app_user.rb
@@ -127,6 +127,15 @@ class AppUser < ApplicationRecord
     end
   end
 
+  ransacker :full_name do |parent|
+    Arel::Nodes::NamedFunction.new('concat', [
+        Arel::Nodes::InfixOperation.new("->>", parent.table[:properties], Arel::Nodes.build_quoted(:first_name)),
+        Arel::Nodes::Quoted.new(' '),
+        Arel::Nodes::InfixOperation.new("->>", parent.table[:properties], Arel::Nodes.build_quoted(:last_name))
+      ]
+    )
+  end
+
   scope :availables, lambda {
     where(["app_users.subscription_state =? or app_users.subscription_state=?",
            "passive", "subscribed"])


### PR DESCRIPTION
Allows searching conversations using the main participant's full_name (first_name + ' ' + last_name) or email.