### PR TITLE
Make active storage configurable by environment variables

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'amazon')
+  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'amazon').to_sym
 
   Rails.application.routes.default_url_options = { host: Chaskiq::Config.get('HOST') }
   config.action_controller.default_url_options = { host: Chaskiq::Config.get('HOST') }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'amazon')
 
   Rails.application.routes.default_url_options = { host: Chaskiq::Config.get('HOST') }
   config.action_controller.default_url_options = { host: Chaskiq::Config.get('HOST') }

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   # config.active_storage.service = :local
 
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'amazon')
 
   Rails.application.routes.default_url_options = { host: Chaskiq::Config.get('HOST') }
   config.action_controller.default_url_options = { host: Chaskiq::Config.get('HOST') }

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   # config.active_storage.service = :local
 
-  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'amazon')
+  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'amazon').to_sym
 
   Rails.application.routes.default_url_options = { host: Chaskiq::Config.get('HOST') }
   config.action_controller.default_url_options = { host: Chaskiq::Config.get('HOST') }

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -4,7 +4,7 @@ test:
 
 local:
   service: Disk
-  root: Chaskiq::Config.fetch("LOCAL_STORAGE_PATH", Rails.root.join("storage"))
+  root: <%= Chaskiq::Config.fetch("LOCAL_STORAGE_PATH", Rails.root.join("storage")) %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -4,7 +4,7 @@ test:
 
 local:
   service: Disk
-  root: <%= Rails.root.join("storage") %>
+  root: Chaskiq::Config.fetch("LOCAL_STORAGE_PATH", Rails.root.join("storage"))
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:


### PR DESCRIPTION
I think that even for production environments, users should be able to select the storage they want to use via environment variables
And there are many object stores that are compatible with the aws s3 protocol other than Amazon, should the s3 endpoints be freely configurable as well?