### PR TITLE
Dismiss dismissible alerts

### DIFF
--- a/app/views/client_tester/show.erb
+++ b/app/views/client_tester/show.erb
@@ -43,6 +43,15 @@
 
   </script>
 
+  <script>
+    var dismissibleAlerts = document.querySelectorAll('.alert-dismissible');
+    dismissibleAlerts.forEach((alert) =>
+      alert.querySelector('[role="button"]').addEventListener('click', function () {
+        alert.classList.add('hidden');
+      })
+    );
+  </script>
+
 <% end %>
 
 <%

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,5 +71,14 @@
       </script>
 
     <% end %>
+
+    <script>
+      var dismissibleAlerts = document.querySelectorAll('.alert-dismissible');
+      dismissibleAlerts.forEach((alert) =>
+        alert.querySelector('[role="button"]').addEventListener('click', function () {
+          alert.classList.add('hidden');
+        })
+      );
+    </script>
   </body>
 </html>

--- a/app/views/shared/_flash.erb
+++ b/app/views/shared/_flash.erb
@@ -1,5 +1,5 @@
 <% flash.each do |key, value| %>
-  <div class="m-8 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+  <div class="m-8 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative alert-dismissible" role="alert">
     <span class="block sm:inline"><%= value %></span>
     <span class="absolute top-0 bottom-0 right-0 px-4 py-3">
       <svg class="fill-current h-6 w-6 text-red-500" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>


### PR DESCRIPTION
Tailwind flash alerts are not dismissible.

An example of this alert showing up is from app/controllers/agents/sessions_controller.rb line 57:
set_flash_message! :notice, :signed_out if signed_out

This is the alert that shows up, which cannot be dismissed. Only goes away after user refreshes the browser:
<img width="763" alt="Screen Shot 2022-08-12 at 3 51 37 PM" src="https://user-images.githubusercontent.com/9791724/184432880-52344d24-826f-4a7c-92bd-49b9c81fe86b.png">

My fix is to add some javascript event listeners to hide the alert element when it's corresponding button has been clicked
