### PR TITLE
Add explicit height so svg shows up on safari

### DIFF
--- a/app/javascript/packages/components/src/components/packageBlocks/TextInput.tsx
+++ b/app/javascript/packages/components/src/components/packageBlocks/TextInput.tsx
@@ -153,6 +153,7 @@ const TextInputButton = styled.div<TextInputButtonProps>`
       : ''}
 
   svg {
+    height: 36px;
     position: absolute;
     left: 4px;
     ${(props) => (props.saved ? tw`text-green-400` : tw`text-white`)}


### PR DESCRIPTION
Arrow svg was not showing up on Safari for the qualifier app package. Added explicit height to make it show up

Before:
<img width="251" alt="Screen Shot 2022-08-17 at 3 43 21 PM" src="https://user-images.githubusercontent.com/94011446/185435356-f79f8ee0-4e87-475b-8a1a-c83d38d95ce7.png">

After:
<img width="230" alt="Screen Shot 2022-08-18 at 11 21 44 AM" src="https://user-images.githubusercontent.com/94011446/185435415-43d0982c-52ef-4b5b-8059-2589a76bbb50.png">
