### PR TITLE
Add overflow so the agent dropdown list scrolls after certain height

### DIFF
--- a/app/javascript/packages/components/src/components/Dropdown.tsx
+++ b/app/javascript/packages/components/src/components/Dropdown.tsx
@@ -68,7 +68,7 @@ export default function Dropdown({
             ${origin || ''}
              mt-2 w-56 rounded-md shadow-lg`}
           >
-            <div className="rounded-md bg-white dark:bg-gray-900 dark:text-gray-100 shadow-xs">
+            <div className="rounded-md bg-white dark:bg-gray-900 dark:text-gray-100 shadow-xs max-h-[85vh] overflow-y-scroll">
               {children}
             </div>
           </div>


### PR DESCRIPTION
Set a max height and overflow scroll on the agent list so that if the list is long, it does not go past the UI

![Screen Shot 2022-08-24 at 1 44 32 PM](https://user-images.githubusercontent.com/94011446/186488805-5b4dd0c0-1659-4f48-970b-cff229100db2.png)
