### PR TITLE
Add i18n to twilio components.

### DIFF
--- a/app/javascript/packages/twilio/CallList.jsx
+++ b/app/javascript/packages/twilio/CallList.jsx
@@ -1,0 +1,232 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { createSubscription, eventsSubscriber, destroySubscription } from './subscriptions';
+
+
+export const CallList = ({ i18n, data, userToken }) => {
+  const CableApp = useRef(createSubscription());
+  const [conferences, setConferences] = useState(data.conferences);
+  const [agentInCall, setAgentInCall] = useState(data.agent_in_call);
+  const [event, setEvent] = useState(null);
+
+  useEffect(() => {
+    eventsSubscriber(CableApp.current, (e) => {
+      setEvent(e);
+    });
+    return () => {
+      console.log('unmounting cable from app container');
+      if (CableApp.current) destroySubscription(CableApp.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!event) return;
+    switch (event.payload.StatusCallbackEvent) {
+      case 'conference-end':
+        removeCall(event.payload);
+        break;
+      case 'participant-join':
+        upsertConference(event);
+        break;
+      case 'participant-hold':
+        updateCallStatus(event.payload, true);
+        break;
+      case 'participant-unhold':
+        updateCallStatus(event.payload, false);
+        break;
+      default:
+        break;
+    }
+  }, [event]);
+
+  function updateCallStatus(payload, mode) {
+    let newConferences = conferences.map((o) => {
+      if (o.key === payload.FriendlyName) {
+        const conf = Object.assign(o.conference, { hold_status: mode });
+        return Object.assign(o, { conference: conf });
+      } else {
+        return o;
+      }
+    });
+    setConferences(newConferences);
+  }
+
+  function removeCall(payload) {
+    let newConferences = conferences.filter(
+      (o) => o.key !== payload.FriendlyName
+    );
+    setConferences(newConferences);
+  }
+
+  function upsertConference(event) {
+    const newConferences = upsert(conferences, event.conference);
+    setConferences(newConferences);
+  }
+
+  function upsert(array, element) {
+    const i = array.findIndex((_element) => _element.key === element.key);
+    if (i > -1) {
+      return array.map((o) => {
+        if (o.key === element.key) {
+          return element;
+        } else {
+          return o;
+        }
+      });
+    } else {
+      return [element, ...array];
+    }
+  }
+
+  function status_class(val) {
+    switch (val) {
+      case 'completed':
+        return 'bg-gray-800 text-white';
+      case 'in-progress':
+        return 'bg-green-500 text-white';
+      default:
+        return 'bg-gray-100 text-black';
+    }
+  }
+
+  function confClass(conf) {
+    if (agentInCall) {
+      return '-m-1 p-3 border border-transparent rounded-full shadow-sm text-white bg-green-300 cursor-default';
+    } else {
+      return '-m-1 p-3 border border-transparent rounded-full shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500';
+    }
+  }
+
+  function confClick(e, conf) {
+    e.preventDefault();
+
+    if (agentInCall) {
+      return false;
+    } else {
+      window.open(
+        conf.url + `&user_token=${userToken}`,
+        'pagename',
+        'resizable,height=260,width=370'
+      );
+      return false;
+    }
+  }
+
+  function goTo(url) {
+    window.parent.postMessage({ type: 'url-push-from-frame', url: url }, '*');
+    return false;
+  }
+
+  return (
+    <div>
+      <div>
+        <ul
+          role="list"
+          className="flex-1 divide-y divide-gray-200 overflow-y-auto"
+        >
+          {conferences.map((conf) => (
+            <li key={`call-conversation-${conf.conversation.key}`}>
+              <div className="group relative flex items-center py-6 px-5">
+                <div className="-m-1 block flex-1 p-1">
+                  <div
+                    className="absolute inset-0 group-hover:bg-gray-50 dark:group-hover:bg-gray-900"
+                    aria-hidden="true"
+                  ></div>
+                  <div className="relative flex min-w-0 flex-1 items-center dark:text-white">
+                    <a
+                      href="#"
+                      className={confClass(conf)}
+                      onClick={(e) => confClick(e, conf)}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-5 w-5 rounded-full"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+                        />
+                      </svg>
+                    </a>
+
+                    <div className="ml-4 truncate">
+                      <p
+                        className={`text-xs font-medium p-1 my-1 rounded inline-block ${status_class(
+                          conf.conference.status
+                        )} `}
+                      >
+                        {conf.conference.status}
+                      </p>
+
+                      {conf.conference.hold_status && (
+                        <p
+                          className={`text-xs font-medium p-1 my-1 rounded inline-block bg-black text-white px-2 mx-2`}
+                        >                         
+                          {i18n.t('twilio_phone.status.onHold')}
+                        </p>
+                      )}
+
+                      <p className="truncate text-md text-gray-600 dark:text-gray-100 font-bold">
+                        {conf.profile.profile_id}
+                      </p>
+
+                      {conf.agent_names.length > 0 && (
+                        <p className="truncate text-xs text-gray-700 p-1 bg-blue-300 flex flex-col">
+                          <span>{i18n.t('twilio_phone.messages.agentsInCall')}</span>
+                          <div className="flex flex-col">
+                            {conf.agent_names.map((o) => (
+                              <span key={o}>{o}</span>
+                            ))}
+                          </div>
+                        </p>
+                      )}
+
+                      {conf.agent_names.length === 0 && (
+                        <p className="truncate text-xs text-gray-700 p-1 bg-yellow-300">
+                          {i18n.t('twilio_phone.messages.noAgentsInCall')}
+                        </p>
+                      )}
+
+                      <button
+                        className="relative flex items-center hover:text-gray-900 underline hover:underline"
+                        onClick={() => goTo(conf.conference.url)}
+                      >
+                        {i18n.t('twilio_phone.buttons.goToConversation')}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        {conferences.length === 0 && (
+          <div className="p-4 relative block w-full border-2 border-gray-300 border-dashed rounded-lg md:p-12 text-center hover:border-gray-400 focus:outline-none">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="mx-auto h-12 w-12 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+              />
+            </svg>
+            <span className="mt-2 block text-sm font-medium text-gray-900">
+              {i18n.t('twilio_phone.messages.noConversations')}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/packages/twilio/PhoneCall.jsx
+++ b/app/javascript/packages/twilio/PhoneCall.jsx
@@ -1,0 +1,263 @@
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react';
+import { Call, CallEnd, Pause } from '../components/src/components/icons';
+import {
+  createSubscription,
+  eventsSubscriber,
+  destroySubscription,
+} from './subscriptions';
+
+export const PhoneCall = ({ data, endpointURL, i18n }) => {
+  const { conversation_key, agents_id, profile_id, user_key, user, on_hold } = data;
+  const CableApp = useRef(createSubscription());
+
+  // Setup Twilio.Device
+  const device = useTwilioDevice(window.token);
+  const [callState, setCallState] = useState(CallStates.Initializing);
+  const [onHold, setOnHold] = useState(on_hold);
+  const [error, setError] = useState();
+
+  /* Join conference */
+  const joinCall = useCallback(() => {
+    console.log('joining', conversation_key);
+    var params = {
+      name: conversation_key,
+      chaskiq_agent: user.id,
+    };
+
+    device.connect(params);
+  }, [device, profile_id, user, conversation_key]);
+
+  const pickUpCall = useCallback(() => {
+    device.__activeConnection.accept();
+  }, [device, callState]);
+
+  const toggleHold = useCallback(async () => {
+    var data = {
+      conversation_key: conversation_key,
+      type: 'hold',
+      profile_id: profile_id,
+      hold_action: !onHold,
+    };
+
+    try {
+      const result = await fetch(endpointURL, {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      console.log('Success:', result);
+    } catch (error) {
+      console.error('Error:', error);
+    }
+  }, [endpointURL, onHold, conversation_key, profile_id]);
+
+  const hangUpCall = useCallback(async () => {
+    device.__activeConnection.disconnect();
+  }, [callState, toggleHold]);
+
+  useEffect(() => {
+    eventsSubscriber(CableApp.current, (event) => {
+      if (event.payload.FriendlyName == conversation_key) {
+        switch (event.payload.StatusCallbackEvent) {
+          case 'participant-hold':
+            setOnHold(true);
+            break;
+          case 'participant-unhold':
+            setOnHold(false);
+            break;
+        }
+      }
+    });
+
+    return () => {
+      console.log('unmounting cable from app container');
+      if (CableApp.current) {
+        destroySubscription(CableApp.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    device.on('ready', function () {
+      console.log('Twilio.Device Ready!');
+      setCallState(CallStates.Idle);
+    });
+
+    device.on('error', function (error) {
+      console.error('Twilio.Device Error: ' + error.message);
+      setError(error.message);
+    });
+
+    device.on('connect', function (conn) {
+      console.log('Twilio.Connected!');
+      device.__activeConnection = conn;
+
+      setCallState(CallStates.InProgress);
+    });
+
+    device.on('disconnect', function (conn) {
+      console.log('Twilio.Disconnect!');
+      device.__activeConnection = conn;
+
+      setCallState(CallStates.Idle);
+    });
+
+    device.on('incoming', function (conn) {
+      console.log('Twilio.Incoming!');
+      device.__activeConnection = conn;
+
+      setCallState(CallStates.Incoming);
+    });
+
+    return () => {
+      console.log('unmounting cable from app container');
+    };
+  }, [device]);
+
+  const callStatus = useMemo(() => {
+    if (error) {
+      return i18n.t('twilio_phone.messages.error', { message: error });
+    }
+
+    if (callState === CallStates.InProgress) {
+      return i18n.t('twilio_phone.messages.inProgress');
+    }
+
+    if (callState === CallStates.Incoming) {
+      return i18n.t('twilio_phone.messages.incoming');
+    }
+
+    return null;
+  }, [error, callState]);
+
+  return (
+    <div className="max-w-7xl mx-auto py-12 sm:px-6 lg:px-8 flex">
+      <div className="max-w-3xl mx-auto justify-center items-center">
+        <div className="relative inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+          <div className="text-lg leading-6 font-medium text-gray-900">
+            <h3 className="panel-title">
+              {i18n.t('twilio_phone.labels.title', {
+                subject: i18n.t(`twilio_phone.labels.${profile_id}`, {
+                  defaultValue: profile_id,
+                }),
+              })}
+            </h3>
+          </div>
+
+          <div className="panel-body">
+            <div className="my-5 max-w-xl text-sm text-gray-500">
+              {callStatus && (
+                <>
+                  <p>
+                    <strong>{i18n.t('twilio_phone.labels.status')}</strong>
+                  </p>
+
+                  <div className="well well-sm" id="call-status">
+                    {callStatus}
+                  </div>
+                </>
+              )}
+            </div>
+
+            <div className="mt-5">
+              {callState === CallStates.InProgress && (
+                <button
+                  className="hangup-button inline-flex items-center px-3 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-red-600 disabled:bg-red-300 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 mr-5"
+                  onClick={hangUpCall}
+                >
+                  <CallEnd className="mr-1" />
+                  {i18n.t('twilio_phone.buttons.hangUp')}
+                </button>
+              )}
+              {callState === CallStates.Incoming && (
+                <button
+                  className="btn-notice inline-flex items-center px-3 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-green-600 disabled:bg-green-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 mr-5"
+                  onClick={pickUpCall}
+                >
+                  <Call className="mr-1" />
+                  {i18n.t('twilio_phone.buttons.pickUp')}
+                </button>
+              )}
+              {callState === CallStates.Idle && (
+                <button
+                  className="btn-notice inline-flex items-center px-3 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-green-600 disabled:bg-green-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 mr-5"
+                  onClick={joinCall}
+                >
+                  <Call className="mr-1" />
+                  {agents_id.length > 0
+                    ? i18n.t('twilio_phone.buttons.join')
+                    : i18n.t('twilio_phone.buttons.pickUp')}
+                </button>
+              )}
+              {(callState === CallStates.InProgress && onHold) && (
+                <button
+                  className="btn-notice inline-flex items-center px-3 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-green-600 disabled:bg-green-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                  onClick={toggleHold}
+                >
+                  <Call className="mr-1" />
+                  {i18n.t('twilio_phone.buttons.holdOff')}
+                </button>
+              )}
+              {(callState === CallStates.InProgress && !onHold) && (
+                <button
+                  className="btn-notice inline-flex items-center px-3 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-gray-600 disabled:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+                  onClick={toggleHold}
+                >
+                  <Pause className="mr-1" />
+                  {i18n.t('twilio_phone.buttons.holdOn')}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function useTwilioDevice(token) {
+  const device = useMemo(() => {
+    const current = new window.Twilio.Device(token, {
+      // Set Opus as our preferred codec. Opus generally performs better, requiring less bandwidth and
+      // providing better audio quality in restrained network conditions. Opus will be default in 2.0.
+      codecPreferences: ['opus', 'pcmu'],
+      // Use fake DTMF tones client-side. Real tones are still sent to the other end of the call,
+      // but the client-side DTMF tones are fake. This prevents the local mic capturing the DTMF tone
+      // a second time and sending the tone twice. This will be default in 2.0.
+      fakeLocalDTMF: true,
+      // Use `enableRingingState` to enable the device to emit the `ringing`
+      // state. The TwiML backend also needs to have the attribute
+      // `answerOnBridge` also set to true in the `Dial` verb. This option
+      // changes the behavior of the SDK to consider a call `ringing` starting
+      // from the connection to the TwiML backend to when the recipient of
+      // the `Dial` verb answers.
+      enableRingingState: true,
+    });
+
+    return current;
+  }, [token]);
+
+  useEffect(() => {
+    return () => {
+      device.destroy();
+    };
+  }, [device]);
+
+  return device;
+}
+
+const CallStates = {
+  Initializing: 'Initializing',
+  Idle: 'Idle',
+  Connecting: 'Connecting',
+  Incoming: 'Incoming',
+  InProgress: 'InProgress'
+};

--- a/app/javascript/packages/twilio/index.js
+++ b/app/javascript/packages/twilio/index.js
@@ -1,0 +1,2 @@
+export * from './CallList';
+export * from './PhoneCall';

--- a/app/javascript/packages/twilio/subscriptions.js
+++ b/app/javascript/packages/twilio/subscriptions.js
@@ -1,0 +1,67 @@
+import actioncable from 'actioncable';
+
+export function createSubscription() {
+  const chaskiq_cable_url = document.querySelector(
+    'meta[name="chaskiq-ws"]'
+    //@ts-ignore
+  ).content;
+
+  const appId = document.querySelector(
+    'meta[name="app-id"]'
+    //@ts-ignore
+  ).content;
+
+  const accessToken = JSON.parse(localStorage.AUTH).auth.accessToken;
+
+  return {
+    events: null,
+    cable: actioncable.createConsumer(
+      `${chaskiq_cable_url}?app=${appId}&token=${accessToken}`
+    ),
+  };
+}
+
+export function destroySubscription(cableApp) {
+  cableApp.events.unsubscribe();
+}
+
+export const eventsSubscriber = (cableApp, cb) => {
+  const appId = document.querySelector(
+    'meta[name="app-id"]'
+    //@ts-ignore
+  ).content;
+
+  // unsubscribe cable ust in case
+  if (cableApp.events) {
+    cableApp.events.unsubscribe();
+  }
+
+  cableApp.events = cableApp.cable.subscriptions.create(
+    {
+      channel: 'EventsChannel',
+      app: appId,
+    },
+    {
+      connected: () => {
+        console.log('connected to events');
+      },
+      disconnected: () => {
+        console.log('disconnected from events');
+      },
+      received: (data) => {
+        switch (data.type) {
+          case '/package/TwilioPhone':
+            cb(data);
+          default:
+            return null;
+        }
+      },
+      notify: () => {
+        console.log('notify!!');
+      },
+      handleMessage: () => {
+        console.log('handle message');
+      },
+    }
+  );
+};

--- a/app/javascript/src/locales/translations.json
+++ b/app/javascript/src/locales/translations.json
@@ -13585,6 +13585,39 @@
       },
       "pm": "PM"
     },
+    "twilio_phone": {
+      "buttons": {
+        "goToConversation": "Go to conversation",
+        "hangUp": "Hang up",
+        "holdOff": "Remove hold",
+        "holdOn": "Put on hold",
+        "join": "Join",
+        "leave": "Leave",
+        "open_call_window": "Open Call Window",
+        "pickUp": "Pick up"
+      },
+      "conversations": {
+        "message_header": "New Phone Call"
+      },
+      "labels": {
+        "client:Anonymous": "Anonymous client",
+        "client:agent": "Agent",
+        "client:support_agent": "Agent",
+        "status": "Status",
+        "title": "Call with %{subject}"
+      },
+      "messages": {
+        "agentsInCall": "AGENTS IN THE CALL:",
+        "error": "ERROR: %{message}",
+        "inProgress": "In-progress",
+        "incoming": "Incoming call...",
+        "noAgentsInCall": "NO AGENTS IN THE CALL",
+        "noConversations": "No active conversations"
+      },
+      "status": {
+        "onHold": "ON HOLD"
+      }
+    },
     "views": {
       "pagination": {
         "first": "&laquo; First",

--- a/app/javascript/twilio_phone_package.js
+++ b/app/javascript/twilio_phone_package.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { I18n } from 'i18n-js';
+import translations from './src/locales/translations.json';
+import { CallList, PhoneCall } from './packages/twilio';
+
+const i18n = new I18n(translations);
+
+// eslint-disable-next-line no-undef
+document.addEventListener('DOMContentLoaded', () => {
+  const data_string = document.querySelector(
+    'meta[name="data"]'
+    //@ts-ignore
+  ).content;
+
+  const endpointURL = document.querySelector(
+    'meta[name="endpoint-url"]'
+    //@ts-ignore
+  ).content;
+
+  const contentType = document.querySelector(
+    'meta[name="content-type"]'
+    //@ts-ignore
+  ).content;
+
+  const userToken = document.querySelector(
+    'meta[name="user-token"]'
+    //@ts-ignore
+  )?.content;
+
+  const data = {
+    ...JSON.parse(data_string),
+  };
+
+  ReactDOM.render(
+    contentType && contentType === 'call-list' ? (
+      <CallList data={data} endpointURL={endpointURL} userToken={userToken} i18n={i18n} />
+    ) : (
+      <PhoneCall data={data} endpointURL={endpointURL} i18n={i18n} />
+    ),
+    document.body.appendChild(document.getElementById('content'))
+  );
+});
+

--- a/app/services/message_apis/twilio_phone/api.rb
+++ b/app/services/message_apis/twilio_phone/api.rb
@@ -64,7 +64,7 @@ module MessageApis::TwilioPhone
       MessageApis::TwilioPhone::Store.set_data(
         params[:conversation_key],
         :holdStatus,
-        params[:action]
+        params[:hold_action]
       )
       # send notification here
       { status: :ok }

--- a/app/services/message_apis/twilio_phone/presenter.rb
+++ b/app/services/message_apis/twilio_phone/presenter.rb
@@ -91,7 +91,8 @@ module MessageApis::TwilioPhone
         user_key: @user["kind"],
         profile_id: @profile.profile_id,
         agents_id: @agents_ids,
-        user: @user
+        user: @user,
+        on_hold: MessageApis::TwilioPhone::Store.get_data(@conversation.key, :holdStatus)
       }.to_json
 
       template = ERB.new <<~SHEET_VIEW
@@ -113,7 +114,7 @@ module MessageApis::TwilioPhone
               window.domain="<%= Rails.application.config.action_controller.asset_host %>";
             </script>
 
-            <script src="<%= "#{ActionController::Base.helpers.compute_asset_path('internal_package_socket.js')}" %>"></script>
+            <script src="<%= "#{ActionController::Base.helpers.compute_asset_path('twilio_phone_package.js')}" %>"></script>
 
             <link rel="stylesheet" href="<%= "#{ActionController::Base.helpers.compute_asset_path('tailwind.css')}" %>" data-turbo-track="reload" media="screen" />
 
@@ -167,7 +168,7 @@ module MessageApis::TwilioPhone
 
             <meta name="endpoint-url" content='<%= @package.hook_url %>'/>
 
-            <script src="<%= "#{ActionController::Base.helpers.compute_asset_path('internal_package_socket.js')}" %>"></script>
+            <script src="<%= "#{ActionController::Base.helpers.compute_asset_path('twilio_phone_package.js')}" %>"></script>
             <link rel="stylesheet" href="<%= "#{ActionController::Base.helpers.compute_asset_path('tailwind.css')}" %>" data-turbo-track="reload" media="screen" />
           </head>
           <body>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,3 +751,30 @@ en:
       email: Email
       company: Company
       phone: Phone
+  twilio_phone:
+    buttons:
+      holdOn: Put on hold
+      holdOff: Remove hold
+      pickUp: Pick up
+      hangUp: Hang up
+      join: Join
+      leave: Leave
+      goToConversation: Go to conversation
+      open_call_window: Open Call Window
+    messages:
+      inProgress: In-progress
+      incoming: Incoming call...
+      error: "ERROR: %{message}"
+      noConversations: No active conversations
+      noAgentsInCall: NO AGENTS IN THE CALL
+      agentsInCall: "AGENTS IN THE CALL:"
+    conversations:
+      message_header: New Phone Call
+    status:
+      onHold: ON HOLD
+    labels:
+      title: "Call with %{subject}"
+      status: Status
+      'client:Anonymous': Anonymous client
+      'client:agent': Agent
+      'client:support_agent': Agent

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -37,7 +37,8 @@ esbuild
             "app/javascript/article.js",
             "app/javascript/docs.js",
             "app/javascript/locales.js",
-            "app/javascript/internal_package_socket.js"
+            "app/javascript/internal_package_socket.js",
+            "app/javascript/twilio_phone_package.js"
         ],
         bundle: true,
         loader: { 


### PR DESCRIPTION
Refactor:
* Split the components defined in internal_package_socket.js into separate components called CallList.jsx and PhoneCall.jsx.
* Extracted the subscriptions snippet into a separate file to be used by CallList.jsx and PhoneCall.jsx
* Added i18n to CallList.jsx and PhoneCall.jsx
* Added icons to buttons  in PhoneCall.jsx

New Features:
* Updated app/services/message_apis/twilio_phone/presenter.rb:95 to return the current hold status of the participant if available.  This is required so that UI always reflects the correct hold state, even if the user reloads the page.

Bug Fixes:
* Updated app/services/message_apis/twilio_phone/api.rb:67 to save the value stored in params[:hold_action] instead of params[:action].

Screenshots:
<img width="566" alt="Screen Shot 2022-08-25 at 9 46 32 AM" src="https://user-images.githubusercontent.com/94011572/186688522-53c0e945-4b33-4904-8ae7-0df0eb1f64e5.png">

<img width="512" alt="Screen Shot 2022-08-25 at 9 46 51 AM" src="https://user-images.githubusercontent.com/94011572/186688617-67735445-d95b-4f66-8fa2-ad614b8f57bd.png">

<img width="490" alt="Screen Shot 2022-08-25 at 9 46 37 AM" src="https://user-images.githubusercontent.com/94011572/186688646-33c713e0-984a-49fa-a8d7-4d6d42723f59.png">




