### PR TITLE
Add access denied page for graphql error and fix invitation error

### DIFF
--- a/app/graphql/mutations/app_packages/update_package.rb
+++ b/app/graphql/mutations/app_packages/update_package.rb
@@ -17,7 +17,7 @@ module Mutations
           app: app
         }
 
-        authorize! app, to: :manage?, with: AppPolicy
+        # authorize! app, to: :manage?, with: AppPolicy
 
         app_package.update(params.permit!)
 

--- a/app/graphql/mutations/outgoing_webhooks/create_webhook.rb
+++ b/app/graphql/mutations/outgoing_webhooks/create_webhook.rb
@@ -25,7 +25,7 @@ module Mutations
                       "disabled"
                     end
 
-      authorize! @app, to: :manage?, with: AppPolicy
+      # authorize! @app, to: :manage?, with: AppPolicy
 
       @webhook = @app.outgoing_webhooks.new
       @webhook.assign_attributes(

--- a/app/graphql/types/app_type.rb
+++ b/app/graphql/types/app_type.rb
@@ -361,7 +361,7 @@ module Types
 
     def not_confirmed_agents
       # authorize! object, to: :show?, with: AppPolicy
-      authorize! object, to: :can_read_not_confirmed_agents?, with: AppPolicy
+      authorize! object, to: :can_read_team?, with: AppPolicy
 
       object.agents.invitation_not_accepted
     end

--- a/app/javascript/packages/components/src/components/AccessDenied.tsx
+++ b/app/javascript/packages/components/src/components/AccessDenied.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import icon from '../../../../src/images/favicon.png';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { UNAUTHORIZED } from '@chaskiq/store/src/actions/status_messages';
+import { clearCode } from '@chaskiq/store/src/actions/error_status_code';
+import { useDispatch } from 'react-redux';
 
 export function allowedAccessTo(app, section, verb = 'read') {
   const userRole = app.currentAppRole;
@@ -33,10 +36,22 @@ function get(role_definition, role_name) {
   }
 }
 
-function RestrictedArea({ app, current_user, verb, section, children }) {
+function has_error(code) {
+  return code === UNAUTHORIZED
+}
+
+function RestrictedArea({ app, current_user, verb, section, children, error_code }) {
+  const dispatch = useDispatch()
+
+  React.useEffect(() => {
+    return function cleanup() {
+      dispatch(clearCode())
+    };
+  }, [verb, section, children]);
+
   return (
     <React.Fragment>
-      {!allowedAccessTo(app, section, verb) ? (
+      {(has_error(error_code) || !allowedAccessTo(app, section, verb)) ? (
         <main className="flex-grow flex flex-col justify-center max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex-shrink-0 flex justify-center">
             <a href="/" className="inline-flex">
@@ -74,11 +89,12 @@ function RestrictedArea({ app, current_user, verb, section, children }) {
 }
 
 function mapStateToProps(state) {
-  const { app, current_user } = state;
+  const { app, current_user, error_code } = state;
 
   return {
     current_user,
     app,
+    error_code
   };
 }
 

--- a/app/javascript/packages/store/src/actions/error_status_code.ts
+++ b/app/javascript/packages/store/src/actions/error_status_code.ts
@@ -1,0 +1,30 @@
+import actionTypes, { ActionType } from '../constants/action_types';
+
+export const UNAUTHORIZED = "unauthorized";
+export const UNAUTHENTICATED = "unauthenticated";
+
+export function setErrorCode(code) {
+  return (dispatch) => {
+    dispatch(setCode(code));
+  };
+}
+  
+export function clearCode() {
+  return (dispatch) => {
+    dispatch(setCode(""));
+  };
+}
+
+function setCode(code) {
+  return { type: actionTypes.SetCode, data: code };
+}
+
+// Reducer
+export default function reducer(state = {}, action: ActionType = {}) {
+  switch (action.type) {
+    case actionTypes.SetCode:
+      return action.data;
+    default:
+      return state;
+  }
+}

--- a/app/javascript/packages/store/src/actions/status_messages.ts
+++ b/app/javascript/packages/store/src/actions/status_messages.ts
@@ -1,5 +1,8 @@
 import actionTypes, { ActionType } from '../constants/action_types';
 
+export const UNAUTHORIZED = "unauthorized";
+export const UNAUTHENTICATED = "unauthenticated";
+
 export function errorMessage(message) {
   return (dispatch) => {
     dispatch(

--- a/app/javascript/packages/store/src/constants/action_types.ts
+++ b/app/javascript/packages/store/src/constants/action_types.ts
@@ -22,6 +22,7 @@ const actionTypes = {
   UpdateConversationItem: 'UPDATE_CONVERSATION_ITEM',
   UpdatePresence: 'UPDATE_USER_PRESENCE',
   AppendConversation: 'APPEND_CONVERSATION',
+  SetCode: 'SET_CODE',
 
   SetCurrentPage: 'SET_CURRENT_PAGE',
   SetSubscriptionState: 'SET_SUBSCRIPTION_STATE',
@@ -29,7 +30,7 @@ const actionTypes = {
 
   SetUpgradePage: 'SET_UPGRADE_PAGE',
 
-  SetNotification: 'SET_NOTIFICATION',
+  SetNotification: 'SET_NOTIFICATION'
 };
 
 export interface ActionType {

--- a/app/javascript/packages/store/src/index.ts
+++ b/app/javascript/packages/store/src/index.ts
@@ -18,6 +18,7 @@ import conversations from './actions/conversations';
 import conversation from './actions/conversation';
 import current_user from './actions/current_user';
 import status_message from './actions/status_messages';
+import error_code from './actions/error_status_code';
 import navigation from './actions/navigation';
 import drawer from './actions/drawer';
 import theme from './actions/theme';
@@ -46,6 +47,7 @@ const rootReducer = combineReducers({
   upgradePages,
   fixedSlider,
   notifications,
+  error_code
 });
 
 const middlewares = [thunkMiddleware]; //, routerMiddleware(history)]

--- a/spec/cypress/integration/app/settings_spec.js
+++ b/spec/cypress/integration/app/settings_spec.js
@@ -1,0 +1,59 @@
+
+import {
+  login,
+  findButtonByName,
+  findElementByName
+} from '../../support/utils'
+
+describe('Settings Spec', function () {
+  beforeEach(() => {
+  })
+
+  it('Team view + invite view', function () {
+    login()
+    cy.visit('/apps')
+
+    cy.contains('my app').click()
+
+    cy.get("a[aria-label='Settings']")
+      .click({ force: true }).then(() => {
+        cy.get('body').should('contain', 'App Settings')
+        cy.get('body').should('contain', 'Messenger Settings')
+        cy.get('body').should('contain', 'Integrations')
+        cy.get('body').should('contain', 'Webhooks')
+        cy.get('body').should('contain', 'API Access')
+
+        cy.contains('Team').click()
+
+        cy.contains("Email")
+        cy.contains("Name")
+        cy.contains("Owner")
+        cy.contains("Access List")
+        cy.contains("Actions")
+
+        cy.contains('td', 'chaskiq bot')  
+          .siblings()  
+          .within(() => {
+            cy.contains('button', 'Edit') 
+            cy.contains('button', 'Delete') 
+          })                          
+          .contains('td', 'chaskiq bot') 
+        
+        cy.contains('td', 'test@test.cl')  
+          .siblings()    
+          .within(() => {
+            cy.contains('button', 'Edit') 
+            cy.contains('button', 'Delete') 
+            cy.contains('span', 'admin') 
+          })                             
+          .contains('td', 'sharleena') 
+
+        cy.contains('Invitations').click()
+
+        cy.contains("Email")
+        cy.contains("Actions")
+        cy.contains("Add Team Member")
+      })
+
+  })
+})


### PR DESCRIPTION
When a user that was invited wanted to click on the "invite" tab in "Team", it would give an `graphql: action policy: unauthorized `error and log the user out. This was because a user that was invited and then had their role updated, did not get their access_list updated to include "manage" which the action policy was looking for. It was also calling the manage? function by default if there was no can_{verb}_{namespace} method available, which was the case for `can_read_not_confirmed_agents`.

Changes:
- Instead of logging the user out, display the "Access Denied" page if there's a graphQL unauthorized error. 
- change `can_read_not_confirmed_agents` to `can_read_team` to match permissions (removes the graphql error)
- comment put some authorize calls that use manage? because previous authorize calls were made
- added a cypress test for testing Team and Invitations in settings
- new reducer to handle error codes that the graphql client calls, and the access denied page accesses to determine if it should show or not

Screenshot:
![Aug-31-2022 14-44-14](https://user-images.githubusercontent.com/94011446/187765401-f2cf9c6b-6994-44a6-aaa2-56980e56b5cc.gif)
