### PR TITLE
add TLD_LENGTH to app config, supports 2 level TLDs (com.br)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -81,6 +81,7 @@ module Chaskiq
     I18n.available_locales = locales
     config.i18n.default_locale = :en
 
+    config.action_dispatch.tld_length = Chaskiq::Config.fetch('TLD_LENGTH', 1)&.to_i
 
   end
 end


### PR DESCRIPTION
ref #790 
This PR fixes the domain resolution for 2-level TLD, like `com.br`, for this to work there is a new environment variable to set
`TLD_LENGTH`, so, for domains like com.br a `TLD_LENGTH=2` will work.