### PR TITLE
Zapier new messages channel

### DIFF
--- a/app/javascript/src/pages/conversations/AppInserter.tsx
+++ b/app/javascript/src/pages/conversations/AppInserter.tsx
@@ -38,14 +38,14 @@ const SortableItem = SortableElement(
           key={`apps-${object.id}`}
           className="bg-gray-100 mb-2 p-4-- flex flex-col justify-between items-center"
         >
-          <div className="border-md bg-white p-3 shadow w-full mx-2 ">
+          <div className="border-md bg-white dark:bg-black p-3 shadow w-full mx-2 ">
             <div className="flex justify-between items-center">
               <div>
-                <p className="text-xs leading-4 font-bold text-gray-700">
+                <p className="text-xs leading-4 font-bold text-gray-700 dark:text-gray-300">
                   {object.name}
                 </p>
 
-                <p className="text-xs leading-6 font-medium text-gray-400">
+                <p className="text-xs leading-6 font-medium text-gray-400 dark:text-gray-600">
                   {JSON.stringify(object.values)}
                 </p>
               </div>

--- a/app/services/message_apis/inbox_sections/presenter.rb
+++ b/app/services/message_apis/inbox_sections/presenter.rb
@@ -149,27 +149,6 @@ module MessageApis::InboxSections
     # them configuration options before it’s inserted. Leaving this option
     # blank will skip configuration.
     def self.configure_hook(kind:, ctx:)
-      nonoo_definitions = [
-        {
-          id: "bubu",
-          label: "fuckya",
-          type: "button",
-          action: {
-            type: "submit"
-          },
-          grid: { xs: "w-full", sm: "w-full" }
-        },
-        {
-          id: "content-url",
-          name: "content-url",
-          label: "content-url",
-          type: "button",
-          action: {
-            type: "submit"
-          }
-        }
-      ]
-
       definitions = base_schema
 
       if %w[user-properties-block

--- a/app/services/message_apis/zapier/presenter.rb
+++ b/app/services/message_apis/zapier/presenter.rb
@@ -2,29 +2,84 @@ module MessageApis::Zapier
   class Presenter
     # Initialize flow webhook URL
     # Sent when an app has been inserted into a conversation, message or the home screen, so that you can render the app.
-    def self.initialize_hook(params)
-      definitions = []
+    def self.initialize_hook(ctx:, kind:)
+      type_value = ctx.dig(:values, :type)
+      block_type = ctx.dig(:values, :block_type)
+
+      if type_value === "content"
+        {
+          # ctx: ctx,
+          values: { block_type: block_type },
+          definitions: [
+            {
+              type: "content"
+            }
+          ]
+        }
+      end
+    end
+
+    def self.content_hook(kind:, ctx:)
       {
-        kind: "initialize",
-        definitions: definitions,
-        values: {}
+        definitions: definitions_for_button(kind, ctx)
       }
     end
 
     # Submit flow webhook URL
     # Sent when an end-user interacts with your app, via a button, link, or text input. This flow can occur multiple times as an end-user interacts with your app.
-    def self.submit_hook(params)
-      definitions = []
+    def self.submit_hook(kind:, ctx:)
+      conversation = Conversation.find_by(key: ctx[:conversation_key])
+
+      conversation.conversation_channels.find_or_create_by(provider: "zapier", provider_channel_id: conversation.id)
+
       {
         kind: "submit",
-        definitions: definitions,
-        values: {}
+        values: {},
+        definitions: definitions_for_button(kind, ctx)
       }
     end
 
     # Configure flow webhook URL (optional)
     # Sent when a teammate wants to use your app, so that you can show them configuration options before it’s inserted. Leaving this option blank will skip configuration.
-    def self.configure_hook(kind:, ctx:); end
+    def self.configure_hook(kind:, ctx:)
+      results = {
+        url: "/ppupu",
+        type: "content",
+        block_type: ctx.dig(:field, :id)
+      }
+      {
+        kind: "initialize",
+        definitions: [],
+        results: results
+      }
+    end
+
+    def self.definitions_for_button(kind, ctx)
+      conversation = Conversation.find_by(key: ctx[:conversation_key])
+      user = conversation.main_participant
+
+      channel = conversation.conversation_channels.find_by(provider: "zapier")
+
+      definition_button = if channel.present?
+                            { type: "text", text: "Channel added", align: "center", style: "notice" }
+                          else
+                            {
+                              id: "channel-create",
+                              label: "Create a Zapier channel for this conversation",
+                              align: "center",
+                              type: "button",
+                              action: {
+                                type: "submit"
+                              }
+                            }
+                          end
+
+      [
+        { type: "text", text: "Zapier integration", align: "center", style: "header" },
+        { type: "text", text: "Adds a Zapier channel in order to notify every message to your Zaps", style: "muted" },
+        definition_button
+      ]
+    end
 
     # Submit Sheet flow webhook URL (optional)
     # Sent when a sheet has been submitted. A sheet is an iframe you’ve loaded in the Messenger that is closed and submitted when the Submit Sheets JS method is called.

--- a/lib/app_packages_catalog.rb
+++ b/lib/app_packages_catalog.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AppPackagesCatalog
+  # rubocop:disable Metrics/MethodLength
   def self.packages(dev_packages: false)
     development_packages = [
       {
@@ -778,12 +779,14 @@ class AppPackagesCatalog
 
       {
         name: "Zapier",
+        capability_list: %w[inbox],
         tag_list: [
           "conversations.started",
           "conversations.assigned",
           "conversations.added",
           "conversations.closed",
-          "users.created"
+          "users.created",
+          "conversation.user.first.comment"
         ],
         description: "Interfaces Zapier template",
         icon: "https://logo.clearbit.com/zapier.com",
@@ -857,6 +860,7 @@ class AppPackagesCatalog
     collection = development_packages + collection if dev_packages
     collection
   end
+  # rubocop:enable Metrics/MethodLength
 
   def self.import
     AppPackage.create(packages)


### PR DESCRIPTION
## Zapier integration for new messages

Zapier integration provides a way to send new messages for the new Zap Trigger, `new-message`. If the trigger is enabled the zap will be subscribed. Then the new conversations will start to be dispatched to the Zap.
For previous conversations, there is a new inbox button that can enable a new channel to start sending messages to the Zap.

![image](https://user-images.githubusercontent.com/11976/228387028-573dd2ca-ae7b-4e04-8573-d69db948b721.png)
