### PR TITLE
Allow setting a different AWS Endpoint for usage with other S3-Alternatives

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,7 +13,7 @@ amazon:
   secret_access_key: <%= Chaskiq::Config.get('AWS_SECRET_ACCESS_KEY') %>
   region: <%= Chaskiq::Config.get('AWS_S3_REGION') || 'us-east-1' %>
   bucket: <%= Chaskiq::Config.get('AWS_S3_BUCKET') %>
-  # endpoint: <%= Chaskiq::Config.get('AWS_S3_ENDPOINT') %>
+  endpoint: <%= Chaskiq::Config.get('AWS_S3_ENDPOINT') %>
   # force_path_style: true
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
If this comment was intentional, don't hesitate closing this PR.
But would be nice if you could merge and create a new Docker Build