### PR TITLE
heroku-postgresql version change

### DIFF
--- a/app.json
+++ b/app.json
@@ -94,7 +94,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "11"
+        "version": "15"
       }
     }
   ],

--- a/app.json
+++ b/app.json
@@ -94,7 +94,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "15"
+        "version": "15" 
       }
     }
   ],


### PR DESCRIPTION
heroku-postgresql does not support version 11 anymore. Version 15 is default now.